### PR TITLE
User Organisation Access Fix

### DIFF
--- a/wildlifecompliance/components/organisations/api.py
+++ b/wildlifecompliance/components/organisations/api.py
@@ -180,9 +180,10 @@ class OrganisationViewSet(viewsets.ModelViewSet):
         if is_internal(self.request) or self.allow_external:
             return Organisation.objects.all()
         elif is_customer(self.request):
-            org_contacts = OrganisationContact.objects.filter(is_admin=True).filter(email=user.email)
-            user_admin_orgs = [org.organisation.id for org in org_contacts]
-            return Organisation.objects.filter(id__in=user_admin_orgs)
+            #org_contacts = OrganisationContact.objects.filter(is_admin=True).filter(email=user.email)
+            #user_admin_orgs = [org.organisation.id for org in org_contacts]
+            #return Organisation.objects.filter(id__in=user_admin_orgs)
+            return user.wildlifecompliance_organisations.all()
         return Organisation.objects.none()
 
     @detail_route(methods=['GET'])

--- a/wildlifecompliance/components/organisations/utils.py
+++ b/wildlifecompliance/components/organisations/utils.py
@@ -5,8 +5,8 @@ import random
 def can_manage_org(organisation, user):
     from wildlifecompliance.components.organisations.models import UserDelegation
     try:
-        UserDelegation.objects.get(organisation=organisation, user=user)
-        return True
+        UserDelegation.objects.get(organisation=organisation,user=user)
+        return can_admin_org(organisation, user)
     except UserDelegation.DoesNotExist:
         pass
     if user.has_perm('wildlifecompliance.system_administrator'):


### PR DESCRIPTION
Fix that allows all users to access their organisation details via the organisations endpoint, now relying on the serializer to hide pins.

Some functions, such as non-admin users updating address and contact details of the organisation, may warrant further review.