### PR TITLE
Document auth

### DIFF
--- a/wildlifecompliance/components/applications/api.py
+++ b/wildlifecompliance/components/applications/api.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from django.db.models import Q
 from django.db import transaction
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
 from rest_framework import viewsets, serializers, status, views
 from rest_framework.decorators import (
@@ -44,6 +43,7 @@ from wildlifecompliance.components.applications.models import (
     ApplicationFormDataRecord,
     ApplicationInvoice,
     ApplicationSelectedActivityPurpose,
+    private_storage,
 )
 from wildlifecompliance.components.applications.services import (
     ApplicationService,
@@ -558,7 +558,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
 
                 document = instance.documents.get_or_create(
                     input_name=section, name=filename)[0]
-                path = default_storage.save(
+                path = private_storage.save(
                     'applications/{}/documents/{}'.format(
                         application_id, filename), ContentFile(
                         _file.read()))

--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -84,7 +84,6 @@ from wildlifecompliance.components.main.models import (
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
-print(private_storage.__dict__)
 logger = logging.getLogger(__name__)
 # logger = logging
 
@@ -116,10 +115,6 @@ def replace_special_chars(input_str, new_char='_'):
 def update_application_comms_log_filename(instance, filename):
     return 'wildlifecompliance/applications/{}/communications/{}/{}'.format(
         instance.log_entry.application.id, instance.id, filename)
-
-def update_application_selected_activity_filename(instance, filename):
-    return 'wildlifecompliance/applications/{}/applicationselectedactivity/{}/{}'.format(
-        instance.selected_activity.application.id, instance.selected_activity.id, filename)
 
 
 def get_temporary_document_collection(collection_id):
@@ -6862,7 +6857,7 @@ class ApplicationSelectedActivityPurpose(models.Model):
 
 
 class IssuanceDocument(Document):
-    _file = models.FileField(upload_to="test/", storage=private_storage)
+    _file = models.FileField(max_length=255, storage=private_storage)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
     selected_activity = models.ForeignKey(

--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -80,6 +80,11 @@ from wildlifecompliance.components.licences.models import (
 from wildlifecompliance.components.main.models import (
     TemporaryDocumentCollection
 )
+
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 # logger = logging
 
@@ -181,7 +186,7 @@ class ActivityPermissionGroup(Group):
 
 class ApplicationDocument(Document):
     application = models.ForeignKey('Application', related_name='documents')
-    _file = models.FileField(upload_to=update_application_doc_filename)
+    _file = models.FileField(upload_to=update_application_doc_filename, storage=private_storage)
     input_name = models.CharField(max_length=255, null=True, blank=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -4076,7 +4081,7 @@ class ApplicationLogDocument(Document):
     log_entry = models.ForeignKey(
         'ApplicationLogEntry',
         related_name='documents')
-    _file = models.FileField(upload_to=update_application_comms_log_filename)
+    _file = models.FileField(upload_to=update_application_comms_log_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -6853,7 +6858,7 @@ class ApplicationSelectedActivityPurpose(models.Model):
 
 
 class IssuanceDocument(Document):
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
     selected_activity = models.ForeignKey(

--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -84,7 +84,7 @@ from wildlifecompliance.components.main.models import (
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
-
+print(private_storage.__dict__)
 logger = logging.getLogger(__name__)
 # logger = logging
 
@@ -116,6 +116,10 @@ def replace_special_chars(input_str, new_char='_'):
 def update_application_comms_log_filename(instance, filename):
     return 'wildlifecompliance/applications/{}/communications/{}/{}'.format(
         instance.log_entry.application.id, instance.id, filename)
+
+def update_application_selected_activity_filename(instance, filename):
+    return 'wildlifecompliance/applications/{}/applicationselectedactivity/{}/{}'.format(
+        instance.selected_activity.application.id, instance.selected_activity.id, filename)
 
 
 def get_temporary_document_collection(collection_id):
@@ -6858,13 +6862,13 @@ class ApplicationSelectedActivityPurpose(models.Model):
 
 
 class IssuanceDocument(Document):
-    _file = models.FileField(max_length=255, storage=private_storage)
+    _file = models.FileField(upload_to="test/", storage=private_storage)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
     selected_activity = models.ForeignKey(
         'ApplicationSelectedActivity',
         related_name='issuance_documents')
-
+    
     class Meta:
         app_label = 'wildlifecompliance'
 

--- a/wildlifecompliance/components/applications/serializers.py
+++ b/wildlifecompliance/components/applications/serializers.py
@@ -1001,7 +1001,7 @@ class BaseApplicationSerializer(serializers.ModelSerializer):
         return self.context['request'].user.is_superuser
 
     def get_documents_url(self, obj):
-        return '/media/applications/{}/documents/'.format(obj.id)
+        return '/private-media/applications/{}/documents/'.format(obj.id)
 
     def get_readonly(self, obj):
         return False

--- a/wildlifecompliance/components/artifact/api.py
+++ b/wildlifecompliance/components/artifact/api.py
@@ -9,7 +9,6 @@ from django.db.models import Q, Min, Max
 from django.db import transaction
 from django.http import HttpResponse
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from wildlifecompliance import settings

--- a/wildlifecompliance/components/artifact/models.py
+++ b/wildlifecompliance/components/artifact/models.py
@@ -28,6 +28,10 @@ from wildlifecompliance.components.main.email import prepare_mail
 from django.core.exceptions import ValidationError
 from wildlifecompliance.components.main.utils import FakeRequest
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 
@@ -693,7 +697,7 @@ class ArtifactCommsLogDocument(Document):
     log_entry = models.ForeignKey(
         ArtifactCommsLogEntry,
         related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -735,7 +739,7 @@ class ArtifactDocument(Document):
     artifact = models.ForeignKey(
             Artifact, 
             related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -753,7 +757,7 @@ class RendererDocument(Document):
     physical_artifact = models.ForeignKey(
         PhysicalArtifact,
         related_name='renderer_documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, null=True, blank=True)
 
     class Meta:

--- a/wildlifecompliance/components/call_email/api.py
+++ b/wildlifecompliance/components/call_email/api.py
@@ -10,7 +10,6 @@ from django.db.models import Q, Min, Max
 from django.db import transaction
 from django.http import HttpResponse
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
 from django.conf import settings
 

--- a/wildlifecompliance/components/call_email/models.py
+++ b/wildlifecompliance/components/call_email/models.py
@@ -22,6 +22,10 @@ from wildlifecompliance.components.main.related_item import can_close_record
 #from wildlifecompliance.components.users.models import CompliancePermissionGroup
 from wildlifecompliance.components.main.models import Region, District
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 def update_compliance_doc_filename(instance, filename):
@@ -656,7 +660,7 @@ class ComplianceFormDataRecord(models.Model):
 class CallEmailDocument(Document):
     call_email = models.ForeignKey('CallEmail', related_name='documents')
     #_file = models.FileField(max_length=255, upload_to=update_call_email_doc_filename)
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -684,7 +688,7 @@ class CallEmailLogDocument(Document):
     #input_name = models.CharField(max_length=255, blank=True, null=True)
     #version_comment = models.CharField(max_length=255, blank=True, null=True)
     #_file = models.FileField(max_length=255, upload_to=update_call_email_comms_log_filename)
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/inspection/api.py
+++ b/wildlifecompliance/components/inspection/api.py
@@ -10,7 +10,6 @@ from django.db.models import Q, Min, Max
 from django.db import transaction
 from django.http import HttpResponse
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from wildlifecompliance import settings

--- a/wildlifecompliance/components/inspection/models.py
+++ b/wildlifecompliance/components/inspection/models.py
@@ -20,6 +20,10 @@ from wildlifecompliance.components.main.related_item import can_close_record
 from wildlifecompliance.components.main.models import Region, District
 from django.core.exceptions import ValidationError
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 def update_inspection_comms_log_filename(instance, filename):
@@ -259,14 +263,14 @@ class InspectionReportDocument(Document):
     log_entry = models.ForeignKey(
         'Inspection',
         related_name='report')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
 
 
 class InspectionTypeApprovalDocument(Document):
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -276,7 +280,7 @@ class InspectionCommsLogDocument(Document):
     log_entry = models.ForeignKey(
         'InspectionCommsLogEntry',
         related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -331,7 +335,7 @@ class InspectionUserAction(models.Model):
 
 class InspectionDocument(Document):
     inspection = models.ForeignKey('Inspection', related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)

--- a/wildlifecompliance/components/legal_case/api.py
+++ b/wildlifecompliance/components/legal_case/api.py
@@ -9,7 +9,6 @@ from django.db.models import Q, Min, Max
 from django.db import transaction
 from django.http import HttpResponse
 from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from wildlifecompliance import settings

--- a/wildlifecompliance/components/legal_case/models.py
+++ b/wildlifecompliance/components/legal_case/models.py
@@ -24,6 +24,10 @@ from treebeard.mp_tree import MP_Node
 from datetime import datetime, timedelta, date
 from django.utils import timezone
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 
@@ -526,7 +530,7 @@ class LegalCaseCommsLogDocument(Document):
     log_entry = models.ForeignKey(
         LegalCaseCommsLogEntry,
         related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -572,7 +576,7 @@ class LegalCaseUserAction(models.Model):
 
 class LegalCaseDocument(Document):
     legal_case = models.ForeignKey(LegalCase, related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -588,7 +592,7 @@ class LegalCaseDocument(Document):
 
 class ProsecutionNoticeDocument(Document):
     legal_case = models.ForeignKey(LegalCase, related_name='prosecution_notices')
-    _file = models.FileField(max_length=255,)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -598,7 +602,7 @@ class ProsecutionNoticeDocument(Document):
 
 class CourtHearingNoticeDocument(Document):
     legal_case = models.ForeignKey(LegalCase, related_name='court_hearing_notices')
-    _file = models.FileField(max_length=255,)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -608,7 +612,7 @@ class CourtHearingNoticeDocument(Document):
 
 class BriefOfEvidenceDocument(Document):
     brief_of_evidence = models.ForeignKey(BriefOfEvidence, related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -622,7 +626,7 @@ class BriefOfEvidenceDocument(Document):
 
 class ProsecutionBriefDocument(Document):
     prosecution_brief = models.ForeignKey(ProsecutionBrief, related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     input_name = models.CharField(max_length=255, blank=True, null=True)
     # after initial submit prevent document from being deleted
     can_delete = models.BooleanField(default=True)
@@ -637,7 +641,7 @@ class ProsecutionBriefDocument(Document):
 
 class LegalCaseGeneratedDocument(Document):
     legal_case = models.ForeignKey(LegalCase, related_name='generated_documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -651,7 +655,7 @@ def update_court_outcome_doc_filename(instance, filename):
 
 class CourtOutcomeDocument(Document):
     court_proceedings = models.ForeignKey(CourtProceedings, related_name='court_outcome_documents')
-    _file = models.FileField(max_length=255, upload_to=update_court_outcome_doc_filename)
+    _file = models.FileField(max_length=255, upload_to=update_court_outcome_doc_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/licences/models.py
+++ b/wildlifecompliance/components/licences/models.py
@@ -28,6 +28,10 @@ from wildlifecompliance.components.main.models import (
     Document
 )
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 # logger = logging
 
@@ -38,7 +42,7 @@ def update_licence_doc_filename(instance, filename):
 
 
 class LicenceDocument(Document):
-    _file = models.FileField(upload_to=update_licence_doc_filename)
+    _file = models.FileField(upload_to=update_licence_doc_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/licences/serializers.py
+++ b/wildlifecompliance/components/licences/serializers.py
@@ -492,7 +492,7 @@ class LicenceDocumentHistorySerializer(serializers.ModelSerializer):
     def get_history_document_url(self, obj):
         doc_id = obj['id']
         pdf = obj['name']
-        url = '/media/wildlifecompliance/licences/{0}/documents/{1}'.format(
+        url = '/private-media/wildlifecompliance/licences/{0}/documents/{1}'.format(
             doc_id, pdf
         )
         return url

--- a/wildlifecompliance/components/main/models.py
+++ b/wildlifecompliance/components/main/models.py
@@ -16,6 +16,10 @@ from wildlifecompliance.components.section_regulation.models import Act
 from wildlifecompliance.settings import SO_TYPE_CHOICES
 from smart_selects.db_fields import ChainedForeignKey
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 
@@ -276,7 +280,7 @@ def update_sanction_outcome_word_filename(instance, filename):
 class SanctionOutcomeWordTemplate(models.Model):
     sanction_outcome_type = models.CharField(max_length=30, choices=SO_TYPE_CHOICES, blank=True,)
     act = models.CharField(max_length=30, choices=Act.NAME_CHOICES, blank=True,)
-    _file = models.FileField(upload_to=update_sanction_outcome_word_filename, max_length=255)
+    _file = models.FileField(upload_to=update_sanction_outcome_word_filename, max_length=255, storage=private_storage)
     uploaded_date = models.DateTimeField(auto_now_add=True, editable=False)
     description = models.TextField(blank=True, verbose_name='description', help_text='')
 

--- a/wildlifecompliance/components/main/models.py
+++ b/wildlifecompliance/components/main/models.py
@@ -229,7 +229,7 @@ class TemporaryDocument(Document):
     temp_document_collection = models.ForeignKey(
         TemporaryDocumentCollection,
         related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
     # input_name = models.CharField(max_length=255, null=True, blank=True)
 
     class Meta:

--- a/wildlifecompliance/components/main/process_document.py
+++ b/wildlifecompliance/components/main/process_document.py
@@ -1,9 +1,7 @@
-from django.core.files.storage import default_storage 
-import os
 from django.core.files.base import ContentFile
 import traceback
 from wildlifecompliance.components.main.models import TemporaryDocument
-
+from wildlifecompliance.components.applications import models
 
 def process_generic_document(request, instance, document_type=None, *args, **kwargs):
     try:
@@ -296,7 +294,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.renderer_documents.get_or_create(
                 input_name=input_name, name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/renderer_documents/{}/{}'.format(
                     instance._meta.model_name, instance.id, input_name, filename), ContentFile(
                     _file.read()))
@@ -307,16 +306,19 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
         elif document_type == 'issuance_documents' and 'filename' in request.data:
             filename = request.data.get('filename')
             _file = request.data.get('_file')
-
+            
             parent_application = instance.application
             document = instance.issuance_documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+
+            private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/{}/{}/{}'.format(
                     'applications', parent_application.id, instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
 
             document._file = path
+            
             document.save()
         # inspection report save
         elif document_type == 'inspection_report' and 'filename' in request.data:
@@ -325,7 +327,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.report.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/report/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -339,7 +342,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.generated_documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/generated_documents/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -354,7 +358,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.court_proceedings.court_outcome_documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/court_outcome_documents/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -369,7 +374,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.prosecution_notices.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/prosecution_notices/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -384,7 +390,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.court_hearing_notices.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/court_hearing_notices/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -399,7 +406,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.intelligence_documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/intelligence_documents/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -414,7 +422,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = comms_instance.documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/communications/{}/documents/{}'.format(
                     instance._meta.model_name, instance.id, comms_instance.id, filename), ContentFile(
                     _file.read()))
@@ -429,7 +438,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 
             document = instance.documents.get_or_create(
                 name=filename)[0]
-            path = default_storage.save(
+            path = private_storage = models.private_storage
+            path = private_storage.save(
                 'wildlifecompliance/{}/{}/documents/{}'.format(
                     instance._meta.model_name, instance.id, filename), ContentFile(
                     _file.read()))
@@ -442,7 +452,8 @@ def save_document(request, instance, comms_instance, document_type, input_name=N
 def save_comms_log_document_obj(instance, comms_instance, temp_document):
     document = comms_instance.documents.get_or_create(
         name=temp_document.name)[0]
-    path = default_storage.save(
+    path = private_storage = models.private_storage
+    path = private_storage.save(
         'wildlifecompliance/{}/{}/communications/{}/documents/{}'.format(
             instance._meta.model_name, 
             instance.id, 
@@ -460,7 +471,8 @@ def save_comms_log_document_obj(instance, comms_instance, temp_document):
 def save_default_document_obj(instance, temp_document):
     document = instance.documents.get_or_create(
         name=temp_document.name)[0]
-    path = default_storage.save(
+    path = private_storage = models.private_storage
+    path = private_storage.save(
         'wildlifecompliance/{}/{}/documents/{}'.format(
             instance._meta.model_name, 
             instance.id, 
@@ -477,7 +489,8 @@ def save_default_document_obj(instance, temp_document):
 def save_issuance_document_obj(instance, temp_document):
     document = instance.issuance_documents.get_or_create(
         name=temp_document.name)[0]
-    path = default_storage.save(
+    path = private_storage = models.private_storage
+    path = private_storage.save(
         'wildlifecompliance/applications/{}/{}/{}/{}'.format(
             instance.application_id,
             instance._meta.model_name,
@@ -495,7 +508,8 @@ def save_renderer_document_obj(instance, temp_document, input_name):
     document = instance.renderer_documents.get_or_create(
             input_name=input_name,
             name=temp_document.name)[0]
-    path = default_storage.save(
+    path = private_storage = models.private_storage
+    path = private_storage.save(
         'wildlifecompliance/{}/{}/renderer_documents/{}/{}'.format(
             instance._meta.model_name,
             instance.id,

--- a/wildlifecompliance/components/offence/models.py
+++ b/wildlifecompliance/components/offence/models.py
@@ -15,6 +15,9 @@ from wildlifecompliance.components.section_regulation.models import SectionRegul
 #from wildlifecompliance.components.users.models import CompliancePermissionGroup
 from wildlifecompliance.components.organisations.models import Organisation
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 class Offence(RevisionedMixin):
     WORKFLOW_CREATE = 'create'
@@ -188,7 +191,7 @@ def update_offence_doc_filename(instance, filename):
 
 class OffenceDocument(Document):
     offence = models.ForeignKey(Offence, related_name='documents')
-    _file = models.FileField(max_length=255, upload_to=update_offence_doc_filename)
+    _file = models.FileField(max_length=255, upload_to=update_offence_doc_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -306,7 +309,7 @@ class OffenceUserAction(models.Model):
 
 class OffenceCommsLogDocument(Document):
     log_entry = models.ForeignKey('OffenceCommsLogEntry', related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/organisations/models.py
+++ b/wildlifecompliance/components/organisations/models.py
@@ -31,6 +31,9 @@ from wildlifecompliance.components.organisations.emails import (
 )
 from wildlifecompliance.components.main.models import Document
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 @python_2_unicode_compatible
 class Organisation(models.Model):
@@ -580,7 +583,7 @@ class Organisation(models.Model):
 
 class OrganisationIntelligenceDocument(Document):
     organisation = models.ForeignKey(Organisation, related_name='intelligence_documents')
-    _file = models.FileField(max_length=255,)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/organisations/models.py
+++ b/wildlifecompliance/components/organisations/models.py
@@ -808,7 +808,8 @@ class OrganisationRequest(models.Model):
     identification = models.FileField(
         upload_to='wildlifecompliance/organisation/requests/%Y/%m/%d',
         null=True,
-        blank=True)
+        blank=True,
+        storage=private_storage)
     status = models.CharField(
         max_length=100,
         choices=STATUS_CHOICES,

--- a/wildlifecompliance/components/returns/models.py
+++ b/wildlifecompliance/components/returns/models.py
@@ -23,6 +23,10 @@ from wildlifecompliance.components.returns.email import (
 import logging
 import reversion
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 
@@ -907,7 +911,7 @@ class ReturnLogEntry(CommunicationsLogEntry):
 
 class ReturnLogDocument(Document):
     log_entry = models.ForeignKey('ReturnLogEntry', related_name='documents')
-    _file = models.FileField(upload_to=update_returns_comms_log_filename)
+    _file = models.FileField(upload_to=update_returns_comms_log_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/sanction_outcome/models.py
+++ b/wildlifecompliance/components/sanction_outcome/models.py
@@ -23,6 +23,10 @@ from wildlifecompliance.management.classes.unpaid_infringement_file import Unpai
 from wildlifecompliance.settings import SO_TYPE_CHOICES, SO_TYPE_INFRINGEMENT_NOTICE, SO_TYPE_CAUTION_NOTICE, \
     SO_TYPE_LETTER_OF_ADVICE, SO_TYPE_REMEDIATION_NOTICE
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
+
 logger = logging.getLogger(__name__)
 
 
@@ -881,7 +885,7 @@ def update_compliance_doc_filename(instance, filename):
 
 class SanctionOutcomeDocument(Document):
     sanction_outcome = models.ForeignKey(SanctionOutcome, related_name='documents')
-    _file = models.FileField(max_length=255, upload_to=update_compliance_doc_filename)
+    _file = models.FileField(max_length=255, upload_to=update_compliance_doc_filename, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -902,7 +906,7 @@ class SanctionOutcomeDocumentAccessLog(models.Model):
 
 class SanctionOutcomeCommsLogDocument(Document):
     log_entry = models.ForeignKey('SanctionOutcomeCommsLogEntry', related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'
@@ -1009,7 +1013,7 @@ class UnpaidInfringementFile(models.Model):
 
 class ActionTakenDocument(Document):
     remediation_action = models.ForeignKey(RemediationAction, related_name='documents')
-    _file = models.FileField(max_length=255)
+    _file = models.FileField(max_length=255, storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/components/users/models.py
+++ b/wildlifecompliance/components/users/models.py
@@ -5,6 +5,9 @@ from django.contrib.auth.models import Group
 from ledger.accounts.models import EmailUser
 from wildlifecompliance.components.main.models import Document, Region, District
 
+from django.conf import settings
+from django.core.files.storage import FileSystemStorage
+private_storage = FileSystemStorage(location=settings.BASE_DIR+"/private-media/", base_url='/private-media/')
 
 #class RegionDistrict(models.Model):
 #
@@ -164,7 +167,7 @@ class ComplianceManagementUserPreferences(models.Model):
 
 class ComplianceUserIntelligenceDocument(Document):
     email_user = models.ForeignKey(EmailUser, related_name='intelligence_documents')
-    _file = models.FileField(max_length=255,)
+    _file = models.FileField(max_length=255,storage=private_storage)
 
     class Meta:
         app_label = 'wildlifecompliance'

--- a/wildlifecompliance/urls.py
+++ b/wildlifecompliance/urls.py
@@ -302,14 +302,17 @@ urlpatterns = [
     url(r'^ledger-private/identification/(?P<emailuser_id>\d+)', views.getLedgerIdentificationFile, name='view_ledger_identification_file'),
     url(r'^ledger-private/senior-card/(?P<emailuser_id>\d+)', views.getLedgerSeniorCardFile, name='view_ledger_senior_card_file'),
 
-] + ledger_patterns + media_serv_patterns
+    url(r'^private-media/', views.getPrivateFile, name='view_private_file'),
+
+] + ledger_patterns #+ media_serv_patterns
 
 if not are_migrations_running():
     DefaultDataManager()
     CollectorManager()
 
 # whitenoise
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.SHOW_DEBUG_TOOLBAR:
     import debug_toolbar

--- a/wildlifecompliance/views.py
+++ b/wildlifecompliance/views.py
@@ -14,9 +14,11 @@ from wildlifecompliance.helpers import is_internal, prefer_compliance_management
     is_compliance_internal_user, is_wildlifecompliance_admin, is_compliance_management_callemail_readonly_user, belongs_to, \
     is_compliance_management_approved_external_user, is_customer
 from wildlifecompliance.forms import *
-from wildlifecompliance.components.applications.models import Application
+from wildlifecompliance.components.applications.models import Application,ApplicationSelectedActivity
 from wildlifecompliance.components.call_email.models import CallEmail
 from wildlifecompliance.components.returns.models import Return
+from wildlifecompliance.components.licences.models import WildlifeLicence
+from wildlifecompliance.components.organisations.models import Organisation, OrganisationContact
 from wildlifecompliance.components.main import utils
 from wildlifecompliance.exceptions import BindApplicationException
 from django.core.management import call_command
@@ -24,6 +26,7 @@ from ledger.accounts.models import EmailUser
 import os
 import mimetypes
 from django.contrib import messages
+from django.db.models import Q
 #from wildlifecompliance.components.users.models import CompliancePermissionGroup
 
 
@@ -267,12 +270,85 @@ def getLedgerSeniorCardFile(request, emailuser_id):
         messages.error(request, 'Unable to find the document')
         return redirect('wc_home')
 
+def is_authorised_to_access_application_document(request,document_id):
+    if is_internal(request):
+        return True
+    elif is_customer(request):
+        user = request.user
+        user_orgs = [org.id for org in user.wildlifecompliance_organisations.all()]
+        return Application.objects.filter(id=document_id).filter(
+            Q(org_applicant_id__in=user_orgs) | 
+            Q(proxy_applicant=user) | Q(submitter=user)).exists()
+    
+def is_authorised_to_access_licence_document(request,document_id):
+    if is_internal(request):
+        return True
+    elif is_customer(request):
+        asa_accepted = ApplicationSelectedActivity.objects.filter(
+            processing_status=ApplicationSelectedActivity.PROCESSING_STATUS_ACCEPTED)
+        user = request.user
+        user_orgs = [org.id for org in user.wildlifecompliance_organisations.all()]
+        return WildlifeLicence.objects.filter(id=document_id).filter(
+                Q(current_application__org_applicant_id__in=user_orgs) |
+                Q(current_application__proxy_applicant=user) |
+                Q(current_application__submitter=user)
+            ).filter(current_application__in=asa_accepted.values_list('application_id', flat=True)).exists()
+    
+def is_authorised_to_access_return_document(request,document_id):
+    if is_internal(request):
+        return True
+    elif is_customer(request):
+        user = request.user
+        user_orgs = [
+            org.id for org in user.wildlifecompliance_organisations.all()]
+        user_licences = [wildlifelicence.id for wildlifelicence in WildlifeLicence.objects.filter(
+            Q(current_application__org_applicant_id__in=user_orgs) |
+            Q(current_application__proxy_applicant=user) |
+            Q(current_application__submitter=user))]
+        return Return.objects.filter(id=document_id).filter(Q(licence_id__in=user_licences)).exists()
+
+def is_authorised_to_access_organisation_document(request,document_id):
+    if is_internal(request):
+        return True
+    elif is_customer(request):
+        user = request.user
+        org_contacts = OrganisationContact.objects.filter(is_admin=True).filter(email=user.email)
+        user_admin_orgs = [org.organisation.id for org in org_contacts]
+        return Organisation.objects.filter(id=document_id).filter(id__in=user_admin_orgs).exists()
+
+def get_file_path_id(check_str,file_path):
+    file_name_path_split = file_path.split("/")
+    #if the check_str is in the file path, the next value should be the id
+    if check_str in file_name_path_split:
+        id_index = file_name_path_split.index(check_str)+1
+        if len(file_name_path_split) > id_index and file_name_path_split[id_index].isnumeric():
+            return int(file_name_path_split[id_index])
+        else:
+            return False
+    else:
+        return False
+
 def is_authorised_to_access_document(request):
 
     if is_internal(request):
         return True
     elif is_customer(request):
-        return True
+        a_document_id = get_file_path_id("applications",request.path)
+        if a_document_id:
+            return is_authorised_to_access_application_document(request,a_document_id)
+        
+        l_document_id = get_file_path_id("licences",request.path)
+        if l_document_id:
+            return is_authorised_to_access_licence_document(request,l_document_id)
+        
+        r_document_id = get_file_path_id("returns",request.path)
+        if r_document_id:
+            return is_authorised_to_access_return_document(request,r_document_id)
+        
+        #for organisation requests, this will fail and they are stored in a request subdir and by date (which is fine for current use cases)
+        o_document_id = get_file_path_id("organisations",request.path)
+        if o_document_id:
+            return is_authorised_to_access_organisation_document(request,a_document_id)
     else:
         return False
 
@@ -280,8 +356,10 @@ def getPrivateFile(request):
 
     if is_authorised_to_access_document(request):
         file_name_path =  request.path
-        full_file_path= settings.BASE_DIR+file_name_path
-        if os.path.isfile(full_file_path) is True:
+        #norm path will convert any traversal or repeat / in to its normalised form
+        full_file_path= os.path.normpath(settings.BASE_DIR+file_name_path) 
+        #we then ensure the normalised path is within the BASE_DIR (and the file exists)
+        if full_file_path.startswith(settings.BASE_DIR) and os.path.isfile(full_file_path):
             extension = file_name_path.split(".")[-1]
             the_file = open(full_file_path, 'rb')
             the_data = the_file.read()

--- a/wildlifecompliance/views.py
+++ b/wildlifecompliance/views.py
@@ -267,3 +267,31 @@ def getLedgerSeniorCardFile(request, emailuser_id):
     except:
         messages.error(request, 'Unable to find the document')
         return redirect('wc_home')
+
+def is_authorised_to_access_document(request):
+
+    if is_internal(request):
+        return True
+    elif is_customer(request):
+        pass
+    else:
+        return False
+
+def getPrivateFile(request):
+
+    if is_authorised_to_access_document(request):
+        file_name_path =  request.path
+        full_file_path= settings.BASE_DIR+file_name_path
+        if os.path.isfile(full_file_path) is True:
+            extension = file_name_path.split(".")[-1]
+            the_file = open(full_file_path, 'rb')
+            the_data = the_file.read()
+            the_file.close()
+            if extension == 'msg':
+                return HttpResponse(the_data, content_type="application/vnd.ms-outlook")
+            if extension == 'eml':
+                return HttpResponse(the_data, content_type="application/vnd.ms-outlook")
+
+            return HttpResponse(the_data, content_type=mimetypes.types_map['.'+str(extension)])
+
+    return HttpResponse()

--- a/wildlifecompliance/views.py
+++ b/wildlifecompliance/views.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 from wildlifecompliance.helpers import is_internal, prefer_compliance_management, is_model_backend, in_dbca_domain, \
     is_compliance_internal_user, is_wildlifecompliance_admin, is_compliance_management_callemail_readonly_user, belongs_to, \
-    is_compliance_management_approved_external_user
+    is_compliance_management_approved_external_user, is_customer
 from wildlifecompliance.forms import *
 from wildlifecompliance.components.applications.models import Application
 from wildlifecompliance.components.call_email.models import CallEmail
@@ -176,7 +176,6 @@ class SecureBaseView(View):
     def post(self, request, *args, **kwargs):
         from wildlifecompliance.management.securebase_manager import SecurePipe
         
-
         securebase_view = SecurePipe(request)
 
         return securebase_view.get_http_response()
@@ -273,7 +272,7 @@ def is_authorised_to_access_document(request):
     if is_internal(request):
         return True
     elif is_customer(request):
-        pass
+        return True
     else:
         return False
 


### PR DESCRIPTION
Change to store all uploaded files in /private-media and adds proper authorisation when attempting to access said files. Only internal users or otherwise appropriately authorised external users may access these documents.