### PR TITLE
Additional payment fixes

### DIFF
--- a/wildlifecompliance/components/applications/api.py
+++ b/wildlifecompliance/components/applications/api.py
@@ -21,6 +21,7 @@ from django.shortcuts import redirect, render
 from wildlifecompliance.components.applications.utils import (
     SchemaParser,
     MissingFieldsException,
+    get_application_applicant_address,
 )
 from wildlifecompliance.components.main.utils import (
     checkout,
@@ -1792,6 +1793,11 @@ class ApplicationViewSet(viewsets.ModelViewSet):
     def final_decision_data(self, request, *args, **kwargs):
         try:
             instance = self.get_object()
+
+            #check if the application applicant has an address, if not then reject the application 
+            if not (get_application_applicant_address(instance)):
+                raise serializers.ValidationError("Applicant has no address.")
+            
             with transaction.atomic():
                 checkbox = CheckboxAndRadioButtonVisitor(
                     instance, request.data

--- a/wildlifecompliance/components/applications/models.py
+++ b/wildlifecompliance/components/applications/models.py
@@ -5566,7 +5566,7 @@ class ApplicationSelectedActivity(models.Model):
                 '%Y-%m-%d'
             )
 
-            is_reissued = False if idtime == o_dtime else True
+            is_reissued = False if i_dtime == o_dtime else True
 
         except BaseException as e:
             logger.error('ASA.is_reissued(): {0}'.format(e))
@@ -6558,7 +6558,7 @@ class ApplicationSelectedActivityPurpose(models.Model):
                 '%Y-%m-%d'
             )
 
-            is_reissued = False if idtime == o_dtime else True
+            is_reissued = False if i_dtime == o_dtime else True
 
         except BaseException as e:
             print(e)

--- a/wildlifecompliance/components/applications/utils.py
+++ b/wildlifecompliance/components/applications/utils.py
@@ -616,3 +616,22 @@ class ActivitySchemaUtil(object):
         iterate_children(schema_group)
 
         return schema_group
+
+def get_application_applicant_address(application):
+
+    try:
+        if application.applicant_type \
+                == application.APPLICANT_TYPE_ORGANISATION:
+            address = application.org_applicant.address
+        elif application.applicant_type == application.APPLICANT_TYPE_PROXY:
+            address = application.proxy_applicant.residential_address
+        else:
+            # applic.applicant_type == application.APPLICANT_TYPE_SUBMITTER
+            address = application.submitter.residential_address
+
+        if address:
+            return True
+        else:
+            return False
+    except:
+        return False

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/applications/application.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/applications/application.vue
@@ -192,7 +192,7 @@
         <div class="col-md-8">
             <div class="row">
                 <template v-if="canIssueDecline && isofficerfinalisation">
-                    <IssueLicence :application="application" :licence_activity_tab="selected_activity_tab_id" @action-tab="actionTabListener" />
+                    <IssueLicence :application="application" :licence_activity_tab="selected_activity_tab_id" :applicantType="applicantType" @action-tab="actionTabListener" />
                 </template>
 
                 <ApplicationAssessments @action-tab="actionTabListener" v-if="isSendingToAssessor || showingConditions" />

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/applications/application_issuance.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/applications/application_issuance.vue
@@ -606,12 +606,8 @@ export default {
             });
 
             var applicantHasAddress = false;
-            console.log(vm.applicantType);
             if (vm.applicantType == 'org')
             {
-                console.log(vm.application);
-                console.log(vm.application.org_applicant);
-                console.log(vm.application.org_applicant.address);
                 if (vm.application.org_applicant.address)
                 {
                     applicantHasAddress = true;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/store/modules/application.js
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/store/modules/application.js
@@ -216,14 +216,14 @@ export const applicationStore = {
         },
         revertApplication({ dispatch, commit, state }) {
             commit(UPDATE_APPLICATION, state.original_application);
-            //dispatch('refreshAddresses');
+            //dispatch('refreshAddresses'); 
         },
         setOriginalApplication({ commit }, application) {
             commit(UPDATE_ORIGINAL_APPLICATION, application);
         },
         setApplication({ dispatch, commit }, application) {
             commit(UPDATE_APPLICATION, application);
-            //dispatch('refreshAddresses');
+            //dispatch('refreshAddresses'); this would cause the organisation/proxy address to be removed from json response body, so has been commented out for now
         },
         refreshApplicationFees({ dispatch, state, getters, rootGetters }) {
             Vue.http.post('/api/application/estimate_price/', {

--- a/wildlifecompliance/frontend/wildlifecompliance/src/store/modules/application.js
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/store/modules/application.js
@@ -180,11 +180,11 @@ export const applicationStore = {
                     dispatch('setOriginalApplication', res.body);
                     dispatch('setApplication', res.body);
                     dispatch('setApplication', {
-                        ...state.application,
-                        application_fee: res.body.adjusted_paid_amount.application_fee,
-                        licence_fee: res.body.adjusted_paid_amount.licence_fee,
-                        update_fee: false,
-                        assess: false,
+                       ...state.application,
+                       application_fee: res.body.adjusted_paid_amount.application_fee,
+                       licence_fee: res.body.adjusted_paid_amount.licence_fee,
+                       update_fee: false,
+                       assess: false,
                     });
                     for(let form_data_record of res.body.data) {
                         dispatch('setFormValue', {
@@ -216,14 +216,14 @@ export const applicationStore = {
         },
         revertApplication({ dispatch, commit, state }) {
             commit(UPDATE_APPLICATION, state.original_application);
-            dispatch('refreshAddresses');
+            //dispatch('refreshAddresses');
         },
         setOriginalApplication({ commit }, application) {
             commit(UPDATE_ORIGINAL_APPLICATION, application);
         },
         setApplication({ dispatch, commit }, application) {
             commit(UPDATE_APPLICATION, application);
-            dispatch('refreshAddresses');
+            //dispatch('refreshAddresses');
         },
         refreshApplicationFees({ dispatch, state, getters, rootGetters }) {
             Vue.http.post('/api/application/estimate_price/', {


### PR DESCRIPTION
Certain scenarios would cause additional payments to not be recorded as complete by the system - potentially leading to confused users paying additional fees multiple times without any apparent result.

This bug would occur for:

- Any reissued licence application
- Any application made on behalf of an applicant without an address

The former occurred due to a variable typo, which has been fixed. The latter has been fixed by only allowing applications to be issued where the applicant (organisation or otherwise) has an address set.

Additionally, another bug was found where the address of an organisation would not load in to the application page - meaning it could not be viewed by the user or validated client-side. This has been fixed by commenting out a function that appeared to be removing the address from the JSON response body required for the application page.

Organisation addresses can now be viewed via the internal application page where set and relevant, application issuance cannot be complete without an applicant address, and all known cases by which additional payments fail to be registered are resolved (with one exception being if the file storage becomes inaccessible during to additional payment process of a reissued licence application).


