### PR TITLE
Filter fixes

### DIFF
--- a/wildlifecompliance/components/licences/api.py
+++ b/wildlifecompliance/components/licences/api.py
@@ -101,44 +101,58 @@ class LicenceFilterBackend(DatatablesFilterBackend):
                 #queryset = queryset.filter(id__in=category_name_licence_ids)
                 queryset = queryset.filter(licence_category__name__iexact=category_name)
 
-            #TODO this filter does not work
+            #TODO: prior to fix the date filters did not work due to an uncaught nonetype error (fixed in the commented code)
+            #however, even when fixed the filter a) excluded surrendered licences and b) took far too long (recorded for as long as 5 minutes!)
+            #the current implementation does not exclude surrendered records and loads in <1s
+            #however, the displayed issue date does not always match what is filtered in some cases - what is displayed/filtered will need review
             if date_from:
-                date_from_licence_ids = []
-                for wildlifelicence in queryset:
-                    # Order the queryset 'from' by issue date licence purpose.
-                    # if (pytz.timezone('utc').localize(datetime.strptime(date_from, '%Y-%m-%d'))
-                    #         <= wildlifelicence.current_activities.order_by('-issue_date').first().issue_date):
-                    #             date_from_licence_ids.append(wildlifelicence.id)
-                    _date_from = pytz.timezone('utc').localize(
+                _date_from = pytz.timezone('utc').localize(
                         datetime.strptime(date_from, '%Y-%m-%d'))
-
-                    _issue_date = wildlifelicence.current_activities.first(
-                        ).get_issue_date()
-
-                    if _date_from <= _issue_date:
-                        date_from_licence_ids.append(wildlifelicence.id)
-
-                queryset = queryset.filter(id__in=date_from_licence_ids)
+                queryset = queryset.filter(current_application__selected_activities__proposed_purposes__issue_date__gte=_date_from)                   
+                #date_from_licence_ids = []
+                #for wildlifelicence in queryset:
+                #    print("licence activities")
+                #    print(wildlifelicence.current_application)
+                #    # Order the queryset 'from' by issue date licence purpose.
+                #    # if (pytz.timezone('utc').localize(datetime.strptime(date_from, '%Y-%m-%d'))
+                #    #         <= wildlifelicence.current_activities.order_by('-issue_date').first().issue_date):
+                #    #             date_from_licence_ids.append(wildlifelicence.id)
+                #    _date_from = pytz.timezone('utc').localize(
+                #        datetime.strptime(date_from, '%Y-%m-%d'))
+                #    
+                #    if (wildlifelicence.current_activities.count()):
+                #        _issue_date = wildlifelicence.current_activities.first(
+                #            ).get_issue_date()
+#
+                #        if _issue_date and _date_from <= _issue_date:
+                #            date_from_licence_ids.append(wildlifelicence.id)
+#
+                #queryset = queryset.filter(id__in=date_from_licence_ids)
                 
-            #TODO this filter does not work
             if date_to:
-                date_to_licence_ids = []
-                for wildlifelicence in queryset:
-                    # Order the queryset 'to' by issue date on licence purpose.
-                    # if (pytz.timezone('utc').localize(datetime.strptime(date_to, '%Y-%m-%d')) + timedelta(days=1)
-                    #         >= wildlifelicence.current_activities.order_by('-issue_date').first().issue_date):
-                    #             date_to_licence_ids.append(wildlifelicence.id)
-                    _date_to = pytz.timezone('utc').localize(
+
+                _date_to = pytz.timezone('utc').localize(
                         datetime.strptime(date_to, '%Y-%m-%d')
                         ) + timedelta(days=1)
-
-                    _issue_date = wildlifelicence.current_activities.first(
-                         ).get_issue_date()
-
-                    if _date_to >= _issue_date:
-                        date_to_licence_ids.append(wildlifelicence.id)
-
-                queryset = queryset.filter(id__in=date_to_licence_ids)
+                queryset = queryset.filter(current_application__selected_activities__proposed_purposes__issue_date__lte=_date_to)   
+                #date_to_licence_ids = []
+                #for wildlifelicence in queryset:
+                #    # Order the queryset 'to' by issue date on licence purpose.
+                #    # if (pytz.timezone('utc').localize(datetime.strptime(date_to, '%Y-%m-%d')) + timedelta(days=1)
+                #    #         >= wildlifelicence.current_activities.order_by('-issue_date').first().issue_date):
+                #    #             date_to_licence_ids.append(wildlifelicence.id)
+                #    _date_to = pytz.timezone('utc').localize(
+                #        datetime.strptime(date_to, '%Y-%m-%d')
+                #        ) + timedelta(days=1)
+#
+                #    if (wildlifelicence.current_activities.count()):
+                #        _issue_date = wildlifelicence.current_activities.first(
+                #            ).get_issue_date()
+#
+                #        if _issue_date and _date_to >= _issue_date:
+                #            date_to_licence_ids.append(wildlifelicence.id)
+#
+                #queryset = queryset.filter(id__in=date_to_licence_ids)
             holder = holder.lower() if holder else 'all'
             if holder != 'all':
                 #holder_licence_ids = []

--- a/wildlifecompliance/components/main/utils.py
+++ b/wildlifecompliance/components/main/utils.py
@@ -531,8 +531,9 @@ def search_reference(reference_number):
     from wildlifecompliance.components.inspection.models import Inspection
     from wildlifecompliance.components.sanction_outcome.models import SanctionOutcome
     from wildlifecompliance.components.artifact.models import Artifact
-    application_list = Application.objects.all().computed_exclude(processing_status__in=[
-        Application.PROCESSING_STATUS_DISCARDED])
+    application_list = Application.objects.all()
+    #this makes the ref search go from under a second to up to 2 minutes - it is better to allow discarded applications to be searched
+    #.computed_exclude(processing_status__in=[Application.PROCESSING_STATUS_DISCARDED])
     licence_list = WildlifeLicence.objects.all().order_by('licence_number').distinct('licence_number')
     returns_list = Return.objects.all().exclude(processing_status__in=[Return.RETURN_PROCESSING_STATUS_FUTURE])
     org_access_request_list = OrganisationRequest.objects.all()
@@ -542,43 +543,53 @@ def search_reference(reference_number):
     result = application_list.filter(lodgement_number=reference_number)
     if result:
         url_string = {'url_string': '/internal/application/' + str(result[0].id)}
+        return url_string
     # Licence
     result = licence_list.filter(licence_number=reference_number)
     if result and not url_string:
         url_string = {'url_string': result[0].licence_document._file.url}
+        return url_string
     # Returns
     result = returns_list.filter(lodgement_number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/return/' + str(result[0].id)}
+        return url_string
     #import ipdb; ipdb.set_trace()
     # Org access reqeust
     result = org_access_request_list.filter(lodgement_number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/organisations/access/' + str(result[0].id)}
+        return url_string
     # CallEmail
     result = CallEmail.objects.filter(number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/call_email/' + str(result[0].id)}
+        return url_string
     # Offence
     result = Offence.objects.filter(lodgement_number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/offence/' + str(result[0].id)}
+        return url_string
     # Legal Case
     result = LegalCase.objects.filter(number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/legal_case/' + str(result[0].id)}
+        return url_string
     # Inspection
     result = Inspection.objects.filter(number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/inspection/' + str(result[0].id)}
+        return url_string
     # Sanction Outcome
     result = SanctionOutcome.objects.filter(lodgement_number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/sanction_outcome/' + str(result[0].id)}
+        return url_string
     # Offence
     result = Artifact.objects.filter(number=reference_number)
     if result and not url_string:
         url_string = {'url_string': '/internal/object/' + str(result[0].id)}
+        return url_string
 
     if url_string:
         return url_string

--- a/wildlifecompliance/components/organisations/api.py
+++ b/wildlifecompliance/components/organisations/api.py
@@ -146,8 +146,8 @@ class OrganisationFilterBackend(DatatablesFilterBackend):
             role = role.lower() if role else 'all'
             if role != 'all':
                 queryset = queryset.filter(role__iexact=role)
-            #TODO work this one out
-            status = status.lower() if status else 'all'
+            
+            status = status.lower().replace(" ","_") if status else 'all'
             if status != 'all':
                 queryset = queryset.filter(status__iexact=status)
 

--- a/wildlifecompliance/components/returns/api.py
+++ b/wildlifecompliance/components/returns/api.py
@@ -88,11 +88,11 @@ class ReturnFilterBackend(DatatablesFilterBackend):
             if date_from:
                 date_from = datetime.strptime(
                     date_from, '%Y-%m-%d') + timedelta(days=1)
-                queryset = queryset.filter(lodgement_date__gte=date_from)
+                queryset = queryset.filter(due_date__gte=date_from)
             if date_to:
                 date_to = datetime.strptime(
                     date_to, '%Y-%m-%d') + timedelta(days=1)
-                queryset = queryset.filter(lodgement_date__lte=date_to)
+                queryset = queryset.filter(due_date__lte=date_to)
 
         return queryset
 

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/common/returns_dashboard.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/common/returns_dashboard.vue
@@ -186,16 +186,21 @@ export default {
             table.column(2).search(value).draw();
         },
         filterDueDateFrom: function(value){
-            this.dateSearch()
-            this.filterReturnStatus = 'All'
+            //this.dateSearch()
+            //this.filterReturnStatus = 'All'
+            this.visibleDatatable.vmDataTable.draw();
         },
         filterDueDateTo: function(value){
-            this.dateSearch()
+            //this.dateSearch()
+            this.visibleDatatable.vmDataTable.draw();
         },
     },
     computed: {
         is_external: function(){
             return this.level == 'external';
+        },
+        visibleDatatable: function() {
+            return this.$refs.return_datatable;
         },
     },
     methods:{

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/organisations/access_dashboard.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/organisations/access_dashboard.vue
@@ -79,6 +79,12 @@ export default {
                 ajax: {
                     "url": helpers.add_endpoint_join(api_endpoints.organisation_requests_paginated,'datatable_list/?format=datatables'),
                     "dataSrc": 'data',
+                    "data": function (d) {
+                        d.organisation = vm.filterOrganisation,
+                        d.applicant = vm.filterApplicant,
+                        d.role = vm.filterRole,
+                        d.status = vm.filterStatus
+                    },
                 },
                 columns:[
                     {
@@ -89,12 +95,15 @@ export default {
                     },
                     {
                         data:"requester",
+                        searchable: false,
                     },
                     {
                         data:"role",
+                        searchable: false,
                     },
                     {
                         data:"status.name",
+                        searchable: false,
                     },
                     {
                         data:"lodgement_date",
@@ -104,6 +113,7 @@ export default {
                     },
                     {
                         data:"assigned_officer",
+                        searchable: false,
                     },
                     {
                         data:"id",

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/search.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/search.vue
@@ -90,8 +90,10 @@
                     <div class="row">
                       <div class="col-lg-12">
                         <div>
-                          <input :disabled="!hasSearchKeywords" type="button" @click.prevent="searchKeyword" class="btn btn-primary" style="margin-bottom: 5px"value="Search"/>
-                          <input type="reset" @click.prevent="clearKeywordSearch" class="btn btn-primary" style="margin-bottom: 5px"value="Clear"/>
+                          <button  v-if="searching" type="button" class="btn btn-primary" style="margin-bottom: 5px" value="Search" disabled>
+                            Search<i class="fa fa-circle-o-notch fa-spin fa-fw"></i></button>
+                          <input v-else type="button" @click.prevent="searchKeyword" class="btn btn-primary" style="margin-bottom: 5px" value="Search" :disabled="!hasSearchKeywords"/>
+                          <input type="reset" @click.prevent="clearKeywordSearch" class="btn btn-primary" style="margin-bottom: 5px" value="Clear"/>
                         </div>
                       </div>
                     </div>
@@ -191,6 +193,7 @@ export default {
             searchReturn: false,
             referenceWord: '',
             keyWord: null,
+            searching:false,
             results: [],
             errors: false,
             errorString: '',
@@ -400,6 +403,7 @@ export default {
           let vm = this;
           if(this.searchKeywords.length > 0)
           {
+            vm.searching=true;
             vm.$http.post('/api/search_keywords.json',{
               searchKeywords: vm.searchKeywords,
               searchApplication: vm.searchApplication,
@@ -411,9 +415,11 @@ export default {
               vm.$refs.keyword_search_datatable.vmDataTable.clear()
               vm.$refs.keyword_search_datatable.vmDataTable.rows.add(vm.results);
               vm.$refs.keyword_search_datatable.vmDataTable.draw();
+              vm.searching=false;
             },
             err => {
               console.log(err);
+              vm.searching=false;
             });
           }
         },

--- a/wildlifecompliance/utils/__init__.py
+++ b/wildlifecompliance/utils/__init__.py
@@ -98,7 +98,7 @@ def serialize_export(app_obj):
     ap = ActivityPurposeMap()
     # cross-reference name_label_pairs with key_value_pairs, and combine
     for key_value in key_value_pairs:
-        for k, v in key_value.iteritems():
+        for k, v in key_value.items():
             name = k.split('.')[-1]
             activity = k.split('.')[0]
             try:
@@ -171,7 +171,7 @@ def search(dictionary, search_list=[''], delimiter='.'):
     """
     result = []
     flat_dict = flatten(dictionary, delimiter=delimiter)
-    for k, v in flat_dict.iteritems():
+    for k, v in flat_dict.items():
         if any(x.lower() in str(v).lower() for x in search_list):
             result.append({k: str(v)})
 
@@ -191,7 +191,7 @@ def search_keys(dictionary, search_list=['help_text', 'label']):
     search_item2 = search_list[1]
     result = []
     flat_dict = flatten(dictionary)
-    for k, v in flat_dict.iteritems():
+    for k, v in flat_dict.items():
         if any(x in k for x in search_list):
             result.append({k: v})
 
@@ -242,7 +242,7 @@ def search_multiple_keys(
     all_search_list = [primary_search] + search_list
     result = []
     flat_dict = flatten(dictionary)
-    for k, v in flat_dict.iteritems():
+    for k, v in flat_dict.items():
         if any(x in k for x in all_search_list):
             result.append({k: v})
 


### PR DESCRIPTION
A number of filter and search functions have been fixed/adjusted so that they work as intended.

Fixes include:
- Licence issue date filter is fixed and is significantly faster (down from up to 5 minutes)*
- Return due date filter now works
- All organisation filters and the search bar now work
- Reference number search is now significantly faster (down from up to 2 minutes)**
- Keyword search now works and no longer iterates through all table records

*some records after filtering appear to have dates outside of the specified filter - this is likely due to the licence being reissued (this is still preferable to how it was working before)
**discarded applications can be found this way, which was not the case before, the exclusion was a primary cause for delay and there does not appear to be an urgent reason to block access to discarded application via this search

Later work should be done to:
- address the issue with licence issue dates - either the display date should be adjusted or the filter, depending on the desired use case and what the data is supposed to represent
- further optimise the search keyword function, potentially by adding pagination prior to formatting the search results (possibly by using a search result serializer)


