### PR TITLE
Inspection Closure Fix

### DIFF
--- a/wildlifecompliance/components/inspection/api.py
+++ b/wildlifecompliance/components/inspection/api.py
@@ -909,7 +909,8 @@ class InspectionViewSet(viewsets.ModelViewSet):
                     #recipient_id = instance.inspection_team_lead_id
 
                 allocated_group = instance.get_compliance_permission_group(instance.region,instance.district,instance.status)
-                if not allocated_group:
+                if not allocated_group and not instance.status in [Inspection.STATUS_CLOSED,
+                    Inspection.STATUS_PENDING_CLOSURE,Inspection.STATUS_DISCARDED]:
                     raise serializers.ValidationError("No allocated group for specified region/district")
                 instance.allocated_group = allocated_group
                 instance.save()


### PR DESCRIPTION
Bug that prevented inspections from being closed.

Per workflow action, an allocated group check would be made on inspections. There no allocated_groups for closed inspections (as well as pending closure and discarded) so an error was being returned. A check has been included so that an allocated group is no longer required for inspections that are closed (,discarded, or pending closure).