### PR TITLE
Allocated Group Error Handling

### DIFF
--- a/wildlifecompliance/components/offence/models.py
+++ b/wildlifecompliance/components/offence/models.py
@@ -149,10 +149,10 @@ class Offence(RevisionedMixin):
         # permissions = Permission.objects.filter(codename=codename, content_type_id=compliance_content_type.id)
 
         # 3. Find groups which has the permission(s) determined above in the regionDistrict.
-        
-        group = ComplianceManagementSystemGroup.objects.get(name=settings.GROUP_OFFICER, region_id=region_id, district_id=district_id)
-        
-        return group
+        try:
+            return ComplianceManagementSystemGroup.objects.get(name=settings.GROUP_OFFICER, region_id=region_id, district_id=district_id)
+        except:
+            return None
 
     @property
     # Rewrite for Region District models

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/inspection/create_inspection_modal.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/inspection/create_inspection_modal.vue
@@ -338,7 +338,7 @@ export default {
                   return res
               }
           } catch(err) {
-                  this.errorResponse = 'Error:' + err.statusText;
+                  this.errorResponse = 'Error:' + err.bodyText;
               }
           
       },

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/legal_case/create_legal_case_modal.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/legal_case/create_legal_case_modal.vue
@@ -209,7 +209,7 @@ export default {
           this.temporary_document_collection_id = val;
       },
       updateDistricts: function() {
-        // this.district_id = null;
+        this.district_id = null;
         this.availableDistricts = [];
         for (let region of this.regions) {
           if (this.region_id === region.id) {
@@ -332,8 +332,9 @@ export default {
                   return res
               }
           } catch(err) {
-                  this.errorResponse = 'Error:' + err.statusText;
-              }
+              console.log(err);
+              this.errorResponse = 'Error:' + err.bodyText;
+          }
           
       },
       //createDocumentActionUrl: async function(done) {


### PR DESCRIPTION
Submission errors for case and inspection errors should now be displayed.

In addition, all errors related to there being no allocated group for a selected region/district should now read clearer for end users.