### PR TITLE
Ledger segregation node update

### DIFF
--- a/wildlifecompliance/components/applications/services.py
+++ b/wildlifecompliance/components/applications/services.py
@@ -1819,12 +1819,6 @@ def do_process_form(
             form_data_record.component_attribute = component_attribute
 
         if action == ApplicationFormDataRecord.ACTION_TYPE_ASSIGN_VALUE:
-            # if not is_draft and not value \
-            #         and schema_name in required_fields:
-            #     missing_item = {'field_name': field_name}
-            #     missing_item.update(required_fields[schema_name])
-            #     missing_fields.append(missing_item)
-            #     continue
             form_data_record.value = value
 
         if action == ApplicationFormDataRecord.ACTION_TYPE_ASSIGN_SUBMIT:
@@ -1834,15 +1828,6 @@ def do_process_form(
                 missing_fields.append(missing_item)
                 continue
             form_data_record.value = value
-
-        # elif action == \
-        #         ApplicationFormDataRecord.ACTION_TYPE_ASSIGN_COMMENT:
-        #     if can_edit_officer_comments:
-        #         form_data_record.officer_comment = officer_comment
-        #     if can_edit_assessor_comments:
-        #         form_data_record.assessor_comment = assessor_comment
-        #     if can_edit_deficiencies:
-        #         form_data_record.deficiency = deficiency
 
         bulk_mgr.add(form_data_record)
         all_form_fields.append(form_data_record)

--- a/wildlifecompliance/components/returns/models.py
+++ b/wildlifecompliance/components/returns/models.py
@@ -1014,21 +1014,21 @@ reversion.register(
         'replaced_by',
         ]
     )
-reversion.register(
-    ReturnTable,
-    follow=[
-        'ret',
-        ]
-    )
-reversion.register(
-    ReturnRow,
-    follow=[
-        'return_table',
-        ]
-    )
-reversion.register(
-    ReturnInvoice,
-    follow=[
-        'invoice_return',
-        ]
-    )
+#reversion.register(
+#    ReturnTable,
+#    follow=[
+#        'ret',
+#        ]
+#    )
+#reversion.register(
+#    ReturnRow,
+#    follow=[
+#        'return_table',
+#        ]
+#    )
+#reversion.register(
+#    ReturnInvoice,
+#    follow=[
+#        'invoice_return',
+#        ]
+#    )

--- a/wildlifecompliance/components/returns/models.py
+++ b/wildlifecompliance/components/returns/models.py
@@ -502,10 +502,9 @@ class Return(SanitiseMixin):
         '''
         QuerySet of authorised licence activity curators for this return.
         '''
-        groups = self.get_permission_groups('return_curator').values_list(
+        groups = list(self.get_permission_groups('return_curator').values_list(
             'id', flat=True
-        )
-
+        ))
         return EmailUser.objects.filter(
             id__in=list(UsersInGroup.objects.filter(group_id__in=groups).values_list('emailuser_id', flat=True))
         ).distinct()

--- a/wildlifecompliance/components/returns/models.py
+++ b/wildlifecompliance/components/returns/models.py
@@ -639,58 +639,61 @@ class Return(SanitiseMixin):
         :return:
         """
         try:
-            # wrap atomic context here to allow natural handling of a Record
-            # Modified concurrent error. (optimistic lock)
-            # get the Return Table record and save immediately to check if
-            # it has been concurrently modified.
-            return_table, created = ReturnTable.objects.get_or_create(
-                name=table_name, ret=self)
-            return_table.save()
+            with transaction.atomic():
+                # wrap atomic context here to allow natural handling of a Record
+                # Modified concurrent error. (optimistic lock)
+                # get the Return Table record and save immediately to check if
+                # it has been concurrently modified.
+                return_table, created = ReturnTable.objects.get_or_create(
+                    name=table_name, ret=self)
+                return_table.save()
 
-            #get all rows from db
-            existing_rows = return_table.returnrow_set.all()
+                #get all rows from db
+                existing_rows = return_table.returnrow_set.all()
 
-            #get rows from request
-            return_rows = [
-                ReturnRow(
-                    return_table=return_table,
-                    data=row) for row in table_rows]
+                #get rows from request
+                return_rows = [
+                    ReturnRow(
+                        return_table=return_table,
+                        data=row) for row in table_rows]
 
-            #identify new rows from data
-            new_indexes = []
-            new_dict = {}
-            for i in return_rows:
-                if i.data and 'rowId' in i.data and 'date' in i.data:
-                    new_indexes.append("{}__{}".format(i.data['rowId'],i.data['date']))
-                    new_dict["{}__{}".format(i.data['rowId'],i.data['date'])] = i.data
+                #identify new rows from data
+                new_indexes = []
+                new_dict = {}
+                for i in return_rows:
+                    if i.data and 'rowId' in i.data and 'date' in i.data:
+                        new_indexes.append("{}__{}".format(i.data['rowId'],i.data['date']))
+                        new_dict["{}__{}".format(i.data['rowId'],i.data['date'])] = i.data
 
-            #identify existing rows (via date and row id)
-            existing_indexes = []
-            existing_dict = {}
-            for i in existing_rows:
-                if i.data and 'rowId' in i.data and 'date' in i.data:
-                    existing_indexes.append("{}__{}".format(i.data['rowId'],i.data['date']))
-                    existing_dict["{}__{}".format(i.data['rowId'],i.data['date'])] = i.data
+                #identify existing rows (via date and row id)
+                existing_indexes = []
+                existing_dict = {}
+                for i in existing_rows:
+                    if i.data and 'rowId' in i.data and 'date' in i.data:
+                        existing_indexes.append("{}__{}".format(i.data['rowId'],i.data['date']))
+                        existing_dict["{}__{}".format(i.data['rowId'],i.data['date'])] = i.data
 
-            #raise error if an existing row is missing
-            for i in existing_indexes:
-                if not i in new_indexes:
-                    raise serializers.ValidationError("Return Table missing previously existing rows.")
+                #raise error if an existing row is missing
+                for i in existing_indexes:
+                    if not i in new_indexes:
+                        raise serializers.ValidationError("Return Table missing previously existing rows.")
 
-            #raise error if an existing row is set to change and the user is not internal
-            if not is_internal(request):
-                for i in new_indexes:
-                    if i in existing_dict:
-                        if new_dict[i] != existing_dict[i]:
-                            raise serializers.ValidationError("User not authorised to edit existing return rows.")
+                #raise error if an existing row is set to change and the user is not internal
+                if not is_internal(request):
+                    for i in new_indexes:
+                        if i in existing_dict:
+                            if new_dict[i] != existing_dict[i]:
+                                raise serializers.ValidationError("User not authorised to edit existing return rows.")
 
-            # delete any existing rows as they will all be recreated
-            existing_rows.delete()
-            ReturnRow.objects.bulk_create(return_rows)
+                # delete any existing rows as they will all be recreated
+                existing_rows.delete()
 
-            # log transaction
-            self.log_user_action(
-                ReturnUserAction.ACTION_SAVE_REQUEST.format(self), request)
+                for return_row in return_rows:
+                    return_row.save()
+                    
+                # log transaction
+                self.log_user_action(
+                    ReturnUserAction.ACTION_SAVE_REQUEST.format(self), request)
 
         except RecordModifiedError:
             raise IntegrityError(
@@ -858,27 +861,19 @@ class ReturnTable(RevisionedMixin):
 
     def set_rows(self, return_rows):
         '''
-        Set all rows associated with this Return Table with a bulk create.
+        Set all rows associated with this Return Table.
 
-        :param return_rows is a list of rows for bulk creation.
+        :param return_rows is a list of rows for creation.
         '''
-        from wildlifecompliance.components.returns.utils import (
-            BulkCreateManager,
-        )
 
         try:
-            bulk_mgr = BulkCreateManager()      # chunking size = 100
-
+            #bulk_mgr = BulkCreateManager() NOTE: this function was previously using a bulk create function. This has been removed as it is incompatible with the sanitisation mixin.
             for record in return_rows:
-
                 return_row = ReturnRow(
                     return_table=self,
                     data=record.data
                 )
-                bulk_mgr.add(return_row)
-
-            bulk_mgr.done()
-
+                return_row.save()
         except Exception as e:
             logger.error('{0} ID: {1} - {2}'.format(
                 'ReturnTable.set_rows()',

--- a/wildlifecompliance/components/returns/models.py
+++ b/wildlifecompliance/components/returns/models.py
@@ -249,7 +249,8 @@ class Return(SanitiseMixin):
     # status that allow a customer to edit a Return.
     CUSTOMER_EDITABLE_STATE = [
         RETURN_PROCESSING_STATUS_DRAFT,
-        RETURN_PROCESSING_STATUS_PAYMENT,
+        RETURN_PROCESSING_STATUS_DUE,
+        RETURN_PROCESSING_STATUS_OVERDUE,
     ]
 
     # List of statuses from above that allow a customer to view a Return.

--- a/wildlifecompliance/components/returns/serializers.py
+++ b/wildlifecompliance/components/returns/serializers.py
@@ -254,17 +254,6 @@ class ReturnSerializer(serializers.ModelSerializer):
         )
         return child_return.activity_list if _return.has_sheet else None
 
-    # def get_sheet_species_list(self, _return):
-    #     """
-    #     Gets the list of Species available for a Return Running Sheet.
-    #     :param _return: Return instance.
-    #     :return: List of species for a Return Running Sheet.
-    #     """
-    #     child_return = self.child if self.child else self.get_child_return(
-    #         _return
-    #     )
-    #     return child_return.species_list if _return.has_sheet else None
-
     def get_sheet_species(self, _return):
         """
         Gets the Species available for a Return Running Sheet.

--- a/wildlifecompliance/components/returns/serializers.py
+++ b/wildlifecompliance/components/returns/serializers.py
@@ -352,6 +352,7 @@ class ReturnSerializer(serializers.ModelSerializer):
         A check that the return is in the correct processing status and
         current user is authorised (assigned) for the processing status.
         '''
+
         with_curator = [
             Return.RETURN_PROCESSING_STATUS_WITH_CURATOR,
         ]
@@ -362,7 +363,7 @@ class ReturnSerializer(serializers.ModelSerializer):
             is_assigned = True
 
         can_be_processed = False
-        if _return.processing_status in with_curator:
+        if _return.has_data and _return.processing_status in with_curator:
             can_be_processed = True
 
         return can_be_processed and not is_assigned

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1535,12 +1535,13 @@ class ReturnData(object):
                     is_empty = False
                     break
             if not is_empty:
-                deficiency_data = post_data['table_name'] + '-deficiency-field'
-                try:
-                    # test if deficiency exists and include in row_data.
-                    row_data[deficiency_data] = post_data[deficiency_data]
-                except MultiValueDictKeyError:
-                    pass
+                #TODO determine what this is and whether or not it is needed (does not appear to be needed in current workflow)
+                #deficiency_data = post_data['table_name'] + '-deficiency-field'
+                #try:
+                #    # test if deficiency exists and include in row_data.
+                #    row_data[deficiency_data] = post_data[deficiency_data]
+                #except MultiValueDictKeyError:
+                #    pass
                 rows.append(row_data)
         return rows
 

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1696,7 +1696,10 @@ class NotifyTransfer(ReturnActivityFacade):
                 ReturnRow(
                     return_table=return_table,
                     data=row) for row in table_rows]
-            ReturnRow.objects.bulk_create(return_rows)
+            
+            for return_row in return_rows:
+                return_row.save()
+
             # log transaction
             from_return.log_user_action(
                 ReturnUserAction.ACTION_SUBMIT_TRANSFER.format(
@@ -1760,7 +1763,9 @@ class AcceptTransfer(ReturnActivityFacade):
                 ReturnRow(
                     return_table=return_table,
                     data=row) for row in table_rows]
-            ReturnRow.objects.bulk_create(return_rows)
+            
+            for return_row in return_rows:
+                return_row.save()
             # log transaction
             from_return.log_user_action(
                 ReturnUserAction.ACTION_ACCEPT_TRANSFER.format(
@@ -1812,7 +1817,9 @@ class DeclineTransfer(ReturnActivityFacade):
                 ReturnRow(
                     return_table=return_table,
                     data=row) for row in table_rows]
-            ReturnRow.objects.bulk_create(return_rows)
+            
+            for return_row in return_rows:
+                return_row.save()
             # log transaction
             from_return.log_user_action(
                 ReturnUserAction.ACTION_DECLINE_TRANSFER.format(

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1171,8 +1171,8 @@ class ReturnData(object):
                 'type': 'grid',
                 'headers': headers,
                 'data': None,
-                #default readonly if not in draft
-                'readonly': self._return.processing_status != Return.RETURN_PROCESSING_STATUS_DRAFT,
+                #default readonly if not in draft, due, overdue
+                'readonly': not self._return.processing_status in Return.CUSTOMER_EDITABLE_STATE,
             }
             try:
                 if self.requires_species():

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -2179,6 +2179,9 @@ class ReturnSheet(object):
         :param request:
         :return:
         """
+
+        #TODO re-examine this process (and others like it) - do we limit the number of new rows? Currently everytime a sheet is saved, every row is deleted and replaced - meaning that at least that number of rows are removed and/or added
+
         for species in self.species_list:
             _data = request.data.get(species)
 

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1277,7 +1277,8 @@ class ReturnData(object):
             return
 
         returns_tables = request.data.get('table_name')
-        table_deficiency = returns_tables + '-deficiency-field'
+        #TODO investigate defiency col - do we need it? commented out for now
+        #table_deficiency = returns_tables + '-deficiency-field'
 
         def _validate_and_save_key_data(key, data):
             '''
@@ -1328,17 +1329,17 @@ class ReturnData(object):
                 else:
                     raise FieldError('Enter data in correct format.')
 
-            elif key == table_deficiency:
-                # table_info = returns_tables.encode('utf-8')
-                table_info = returns_tables
-                table_rows = self._get_table_rows(
-                    table_info, data)
-                if self.requires_species():
-                    table_info = self._species
-                    # table_rows = None
-                if table_rows:
-                    self._return.save_return_table(
-                        table_info, table_rows, request)
+            #elif key == table_deficiency:
+            #    # table_info = returns_tables.encode('utf-8')
+            #    table_info = returns_tables
+            #    table_rows = self._get_table_rows(
+            #        table_info, data)
+            #    if self.requires_species():
+            #        table_info = self._species
+            #        # table_rows = None
+            #    if table_rows:
+            #        self._return.save_return_table(
+            #            table_info, table_rows, request)
 
         for key in request.data.keys():
             data = request.data
@@ -1408,7 +1409,7 @@ class ReturnData(object):
         tables = []
 
         # retain deficiencies when building.
-        self.set_table_deficiency(rows)
+        #self.set_table_deficiency(rows)
 
         for resource in self._return.return_type.resources:
             resource_name = resource.get('name')

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1289,6 +1289,8 @@ class ReturnData(object):
                 self._return.save()
 
             elif key == "nilNo":
+                self._return.nil_return = False
+                self._return.save()
                 # Not submitting a Nil return so save data.
                 is_valid_data = self._is_post_data_valid(
                     # returns_tables.encode('utf-8'),
@@ -1310,7 +1312,6 @@ class ReturnData(object):
                         for species in self.species_list:
                             try:
                                 species_data = data[species]
-
                             except KeyError:
                                 continue
 
@@ -1339,36 +1340,8 @@ class ReturnData(object):
                     self._return.save_return_table(
                         table_info, table_rows, request)
 
-        # def _parse_species_data(data):
-        #     '''
-        #     parse species data for storing.
-        #     '''
-        #     import json
-
-        #     _parsed_data = request.data
-        #     _json_data = json.loads(data)
-
-        #     for _data in _json_data:
-        #         for _key in _data.keys():
-        #             try:
-        #                 _value = _data[_key]['value']
-        #                 _key_name = '{0}::{1}'.format(returns_tables, _key)
-        #                 _parsed_data[_key_name] = _value
-
-        #             except KeyError:
-        #                 pass
-
-        #     return _parsed_data
-
         for key in request.data.keys():
             data = request.data
-
-            # if key in self._species_list:
-            #     parsed_data = _parse_species_data(request.data[key])
-            #     self.set_species(key)
-            #     data = parsed_data
-            #     key = "nilNo"
-
             _validate_and_save_key_data(key, data)
 
     def get_species_list(self):
@@ -1473,7 +1446,7 @@ class ReturnData(object):
         """
         table_rows = self._get_table_rows(tables_info, post_data)
         if len(table_rows) == 0:
-            return False
+            return True #empty table is valid if resetting return
         schema = Schema(
             self._return.return_type.get_schema_by_name(tables_info))
         if not schema.is_all_valid(table_rows):
@@ -1501,7 +1474,6 @@ class ReturnData(object):
                     continue
                 _data[key] = value
             rows.append(_data)
-
         return rows
 
     def _get_table_rows(self, table_name, post_data):

--- a/wildlifecompliance/components/returns/services.py
+++ b/wildlifecompliance/components/returns/services.py
@@ -1161,7 +1161,6 @@ class ReturnData(object):
                     "name": f.data['name'],
                     "required": f.required,
                     "type": f_type,
-                    "readonly": False,
                 }
                 if f.is_species:
                     header["species"] = f.species_type
@@ -1171,7 +1170,9 @@ class ReturnData(object):
                 'label': resource.get('title', resource.get('name')),
                 'type': 'grid',
                 'headers': headers,
-                'data': None
+                'data': None,
+                #default readonly if not in draft
+                'readonly': self._return.processing_status != Return.RETURN_PROCESSING_STATUS_DRAFT,
             }
             try:
                 if self.requires_species():

--- a/wildlifecompliance/components/returns/utils.py
+++ b/wildlifecompliance/components/returns/utils.py
@@ -635,10 +635,10 @@ class SpreadSheet(object):
                 row_data[key.lower()] = value[row_num] \
                     if value[row_num] is not None else ''
 
-            # create deficiency key as part of row data
+            # create deficiency key as part of row data #TODO investigate/remove
             table_name = self.ret.return_type.resources[0]['name']
-            table_deficiency = table_name + '-deficiency-field'
-            row_data[table_deficiency] = None
+            #table_deficiency = table_name + '-deficiency-field'
+            #row_data[table_deficiency] = None
 
             self.rows_list.append(row_data)
 

--- a/wildlifecompliance/components/returns/utils.py
+++ b/wildlifecompliance/components/returns/utils.py
@@ -252,7 +252,9 @@ def _create_return_data_from_post_data(ret, tables_info, post_data):
             ReturnRow(
                 return_table=return_table,
                 data=row) for row in rows]
-        ReturnRow.objects.bulk_create(return_rows)
+        
+        for return_row in return_rows:
+            return_row.save()
 
 
 class BulkCreateManager(object):
@@ -350,7 +352,7 @@ class ReturnSpeciesUtility(ReturnUtility):
         Set list of species for the Return.
         '''
         species_list = []
-        return_table = []
+        return_tables = []
 
         try:
             if isinstance(a_species_list, list):
@@ -362,12 +364,12 @@ class ReturnSpeciesUtility(ReturnUtility):
 
             for specie_name in species_list:
                 name_id = self.get_id_from_species_name(specie_name)
-                return_table.append(
+                return_tables.append(
                     ReturnTable(name=name_id, ret_id=str(self._return.id))
                 )
 
-            if return_table:
-                ReturnTable.objects.bulk_create(return_table)
+            for return_table in return_tables:
+                return_table.save()
 
         except Exception as e:
             raise Exception('{0} ReturnID: {1} - {2}'.format(
@@ -704,7 +706,9 @@ class Regulation15Sheet(SpreadSheet):
                 ReturnRow(
                     return_table=return_table,
                     data=row) for row in self.rows_list]
-            ReturnRow.objects.bulk_create(return_rows)
+
+            for return_row in return_rows:
+                return_row.save()
 
         return True
 
@@ -747,7 +751,9 @@ class ReturnDataSheet(SpreadSheet):
                 ReturnRow(
                     return_table=return_table,
                     data=row) for row in self.rows_list]
-            ReturnRow.objects.bulk_create(return_rows)
+
+            for return_row in return_rows:
+                return_row.save()
 
         return True
 

--- a/wildlifecompliance/components/returns/utils_schema.py
+++ b/wildlifecompliance/components/returns/utils_schema.py
@@ -344,7 +344,8 @@ class Schema:
     def field_validation_error(self, field_name, value):
         field = self.get_field_by_mame(field_name)
         if field is not None:
-            return field.validation_error(value)
+            #TODO this does not work, fix it if it is required (data value validation, can be probably be handled by assessor review in the case)
+            return None #field.validation_error(value)
         else:
             raise Exception(
                 "The field '{}' doesn't exists in the schema. Should be one of {}" .format(
@@ -494,8 +495,8 @@ class Schema:
 
     def is_all_valid(self, rows):
         for row in rows:
-            #print("======Printing from is_all_valid====")
-            #print(row)
+            print("======Printing from is_all_valid====")
+            print(row)
             if not self.is_row_valid(row):
                 return False
         return True

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
@@ -182,7 +182,6 @@ export default {
     },
     getSpecies: async function(_id){
       var specie_id = _id
-
       if (this.species_cache[this.returns.species]==null) {
         // cache currently displayed species json
         this.species_cache[this.returns.species] = this.returns.table[0]['data']

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
@@ -5,7 +5,7 @@
       index="return"
   >
     <div class="card-body">
-    <AmendmentRequestDetails v-show="is_external"/>
+        <AmendmentRequestDetails v-show="is_external"/>
         <div class="col-md-12" v-if="returns.has_species">
             <div class="form-group">
                 <label class="fw-bold" for="">Species Available:</label>
@@ -229,7 +229,7 @@ export default {
       }
       
       $(vm.$refs.selected_species).select2({
-          theme: "bootstrap",
+          theme: "bootstrap-5",
           allowClear: true,
           placeholder: "Select..."
       }).

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/enter_return.vue
@@ -120,7 +120,8 @@ export default {
       return this.spreadsheet != null ? this.spreadsheet.name: '';
     },
     isReadOnly: function() {
-      this.readonly = this.is_external && this.returns.is_draft ? false : true;
+      this.readonly =  this.returns.is_draft ? false : true;
+      //this.is_external &&
       return this.readonly;
     },
     refreshGrid: function() {

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/return.vue
@@ -153,7 +153,6 @@ export default {
       self.spinner_continue = andContinue;
       self.form=document.forms.external_returns_form;
       var data = new FormData(self.form);
-
       // cache only used in Returns sheets
       for (const speciesID in self.species_cache) { // Running Sheet Cache
         let speciesJSON = []
@@ -173,46 +172,46 @@ export default {
         data.append('transfer', speciesJSON)
       }
       let request = fetch_util.fetchUrl(helpers.add_endpoint_json(api_endpoints.returns,self.returns.id+'/save'),{method:'POST', body:data},{
-                      emulateJSON:true,
-                    })
-                request.then((response)=>{
-                      let species_id = self.returns.sheet_species;
-                      self.setReturns(response);
-                      if (species_id != null) {
-                        self.returns.sheet_species = species_id;
-                        self.returns.species = species_id;
-                      }
-                      self.is_saving = false
-                      self.disable_submit = false;
-                      self.disable_exit = false;
-                      self.disable_continue = false;
-                      self.spinner_exit = false;
-                      self.spinner_continue = false;
-                      if (andContinue) { 
+          emulateJSON:true,
+      })
+      request.then((response)=>{
+            let species_id = self.returns.sheet_species;
+            self.setReturns(response);
+            if (species_id != null) {
+              self.returns.sheet_species = species_id;
+              self.returns.species = species_id;
+            }
+            self.is_saving = false
+            self.disable_submit = false;
+            self.disable_exit = false;
+            self.disable_continue = false;
+            self.spinner_exit = false;
+            self.spinner_continue = false;
+            if (andContinue) { 
 
-                        swal.fire( 'Save', 
-                              'Return Details Saved', 
-                              'success'
-                        )
+              swal.fire( 'Save', 
+                    'Return Details Saved', 
+                    'success'
+              )
 
-                      } else { // route back to main dashboard
+            } else { // route back to main dashboard
 
-                        this.$router.push({name:"external-applications-dash",});
+              this.$router.push({name:"external-applications-dash",});
 
-                      }
-                    },(error)=>{
-                      self.is_saving = false
-                      self.disable_submit = false;
-                      self.disable_exit = false;
-                      self.disable_continue = false;
-                      self.spinner_exit = false;
-                      self.spinner_continue = false;
-                      console.log(error);
-                      swal.fire('Error',
-                           'There was an error saving your return details.<br/>' + error.body,
-                           'error'
-                      )
-                    });
+            }
+          },(error)=>{
+            self.is_saving = false
+            self.disable_submit = false;
+            self.disable_exit = false;
+            self.disable_continue = false;
+            self.spinner_exit = false;
+            self.spinner_continue = false;
+            console.log(error);
+            swal.fire('Error',
+                  'There was an error saving your return details.<br/>' + error.body,
+                  'error'
+            )
+          });
     },
     save_and_submit: async function(e) {
       const self = this;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/external/returns/return.vue
@@ -178,8 +178,10 @@ export default {
                 request.then((response)=>{
                       let species_id = self.returns.sheet_species;
                       self.setReturns(response);
-                      self.returns.sheet_species = species_id;
-                      self.returns.species = species_id;
+                      if (species_id != null) {
+                        self.returns.sheet_species = species_id;
+                        self.returns.species = species_id;
+                      }
                       self.is_saving = false
                       self.disable_submit = false;
                       self.disable_exit = false;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -41,14 +41,14 @@
                                          @input="update($event,key,row_no)"
                                   />
                           </div>
-                          <div class="col-sm-1">
+                          <div v-if="!readonly" class="col-sm-1">
                             <button class="btn btn-danger btn-md" @click.prevent="removeRow(row_no)" ><i class="bi bi-trash"></i></button>
                           </div>
                 </div>
               </div>
           </div>
           <div >
-             <button class="btn btn-primary btn-md" @click.prevent="addRow()" >Add Row</button>
+             <button v-if="!readonly" class="btn btn-primary btn-md" @click.prevent="addRow()" >Add Row</button>
           </div>
      </div>
 </template>
@@ -88,6 +88,7 @@ const GridBlock = {
     },
   },
   mounted: function() {
+    console.log(this.readonly)
     if (this.field_data.length > 0) {
       for (const i in this.field_data[0]) {
         if (this.field_data[0][i].error === undefined) {

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -88,7 +88,6 @@ const GridBlock = {
     },
   },
   mounted: function() {
-    console.log(this.readonly)
     if (this.field_data.length > 0) {
       for (const i in this.field_data[0]) {
         if (this.field_data[0][i].error === undefined) {
@@ -109,6 +108,7 @@ const GridBlock = {
         fieldObj[key] = {'value':'', 'error':''};
       };
       self.field_data.push(fieldObj);
+      console.log(self.field_data)
     },
     removeRow: function(row_num) {
       const self = this;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -108,7 +108,6 @@ const GridBlock = {
         fieldObj[key] = {'value':'', 'error':''};
       };
       self.field_data.push(fieldObj);
-      console.log(self.field_data)
     },
     removeRow: function(row_num) {
       const self = this;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -13,54 +13,38 @@
           <CommentBlock :label="label" :name="name" :field_data="getDeficiencyField" />
 
           <div class="grid-container">
-              <div v-if="headers">
-                  <label v-for="header in headers" >
-                      <input class="form-control" v-model="header.label" disabled="disabled" />
-                      <div class="grid-item" v-for ="(field, row_no) in field_data" >
-                          <div id="header.name" v-for="(title,key) in field"
-                              :name="`${name}::${header.name}`" :key="`f_${key}`" >
-
-                              <div v-if="header.type === 'date'" >
-                                  <input type="date"
-                                         :id="header.name + '::' + row_no"
-                                         :disabled="header.readonly"
-                                         :name="name + '::' + header.name"
-                                         class="form-control"
-                                         placeholder="DD/MM/YYYY"
-                                         :v-model="setDateValue(title.value, row_no, header.name, header.readonly)"
-                                         :required="isRequired"
-                                  />
-                              </div>
-
-                              <div v-if="header.type === 'string'">
-                                  <input :disabled="header.readonly"
-                                         type="text"
-                                         :id="header.name + '::' + row_no"
-                                         class="form-control"
-                                         :name="name + '::' + header.name"
-                                         v-model="title.value"
-                                         :required="isRequired"
-                                  />
-                              </div>
-
-                              <div v-if="header.type === 'number'" >
-                                  <input :disabled="header.readonly"
-                                         :id="header.name + '::' + row_no"
+              <div class="col-sm-6 form-group" v-if="headers">
+                  <div class="row">
+                      <div class="col-sm-1" v-for="header in headers" >
+                                  <input disabled="true"
                                          type="text"
                                          class="form-control"
-                                         :name="name + '::' + header.name"
-                                         v-model="title.value"
-                                         :required="isRequired"
+                                         :value="header.label"
                                   />
-                              </div>
-
                           </div>
-                      </div>
-                  </label>
+                      
+                  </div>
+                  
+                  <div class="grid-item row" v-for ="(field, row_no) in field_data" >
+                    
+                          <div class="col-sm-1" id="field.name" v-for="(title,key) in field"
+                              :name="`${name}::${key}`" :key="`f_${key}`" >
+                                  <input :disabled="readonly"
+                                         type="text"
+                                         :id="key + '::' + row_no"
+                                         class="form-control"
+                                         :name="name + '::' + key"
+                                         :required="isRequired"
+                                         :v-model="field_data[row_no][key].value"
+                                         :value="field_data[row_no][key].value"
+                                         @input="update($event,key,row_no)"
+                                  />
+                          </div>
+                </div>
               </div>
           </div>
           <div >
-             <button v-show="showAddRow" class="btn btn-link" @click.prevent="addRow()" >Add Row</button>
+             <button class="btn btn-primary btn-md" @click.prevent="addRow()" >Add Row</button>
           </div>
      </div>
 </template>
@@ -82,7 +66,6 @@ const GridBlock = {
   props: ['field_data','headers','name', 'label', 'id', 'help_text', 'help_text_url', 'readonly', 'isRequired'],
   components: {HelpText, HelpTextUrl, CommentBlock},
   data: function() {
-    var grid_item = [{'id': 0, 'name': '', 'value': ''}];
     return {
       show_add_row: false,
     }
@@ -99,17 +82,27 @@ const GridBlock = {
       return this.show_add_row
     },
   },
+  mounted: function() {
+    if (this.field_data.length > 0) {
+      for (const i in this.field_data[0]) {
+        if (this.field_data[0][i].error === undefined) {
+          this.field_data[0][i].error = "";
+        }
+      }
+    }
+  },
   methods: {
+    update: function($event,key,index) {
+      this.field_data[index][key].value = $event.target.value;
+    },
     addRow: function(e) {
       const self = this;
-      self.grid_item = self._props['field_data']; // field_data is an Array of grid items.
-      let index = self.grid_item.length;
-      let fieldObj = Object.assign({}, self.grid_item[0]);
+      let fieldObj = Object.assign({}, this.field_data[0]);
       // schema data type on each field is validated - error value required.
       for(let key in fieldObj) {
         fieldObj[key] = {'value':'', 'error':''};
       };
-      self.grid_item.push(fieldObj);
+      self.field_data.push(fieldObj);
     },
     addColumn: function(e) {
     },

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -1,6 +1,6 @@
 <template lang="html">
      <div>
-          <label :id="id" :required="isRequired" > {{ label }} </label>
+          <label :id="id" :required="isRequired" class="fw-bold"> {{ label }} </label>
 
           <template v-if="help_text">
               <HelpText :help_text="help_text" />
@@ -10,15 +10,16 @@
               <HelpTextUrl :help_text_url="help_text_url" />
           </template>
 
-          <CommentBlock :label="label" :name="name" :field_data="getDeficiencyField" />
+          <CommentBlock :label="label" :field_data="getDeficiencyField" />
 
           <div class="grid-container">
               <div class="col-sm-6 form-group" v-if="headers">
-                  <div class="row">
-                      <div class="col-sm-1" v-for="header in headers" >
+                  <div class="grid-item row">
+                      
+                      <div class="col-sm-1 grid-column" v-for="header in headers" >
                                   <input disabled="true"
                                          type="text"
-                                         class="form-control"
+                                         class="form-control grid-element"
                                          :value="header.label"
                                   />
                           </div>
@@ -26,19 +27,22 @@
                   </div>
                   
                   <div class="grid-item row" v-for ="(field, row_no) in field_data" >
-                    
-                          <div class="col-sm-1" id="field.name" v-for="(title,key) in field"
+                          
+                          <div class="col-sm-1 grid-column" id="field.name" v-for="(title,key) in field"
                               :name="`${name}::${key}`" :key="`f_${key}`" >
                                   <input :disabled="readonly"
                                          type="text"
                                          :id="key + '::' + row_no"
-                                         class="form-control"
+                                         class="form-control grid-element"
                                          :name="name + '::' + key"
                                          :required="isRequired"
                                          :v-model="field_data[row_no][key].value"
                                          :value="field_data[row_no][key].value"
                                          @input="update($event,key,row_no)"
                                   />
+                          </div>
+                          <div class="col-sm-1">
+                            <button class="btn btn-danger btn-md" @click.prevent="addRow()" ><i class="bi bi-trash"></i></button>
                           </div>
                 </div>
               </div>
@@ -104,6 +108,9 @@ const GridBlock = {
       };
       self.field_data.push(fieldObj);
     },
+    removeRow: function(e) {
+
+    },
     addColumn: function(e) {
     },
     addArea: function(e) {
@@ -145,7 +152,15 @@ export default GridBlock;
         grid-column: 1 / 1;
         grid-row: 1 / 1;
         border: 1px solid #ffffff;
+        margin: auto;    
     }
+    .grid-column {
+        padding: 1px !important;
+    }
+    .grid-element {
+        margin: 1px !important;
+    }
+
 </style>
 
 

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/forms/grid.vue
@@ -10,10 +10,10 @@
               <HelpTextUrl :help_text_url="help_text_url" />
           </template>
 
-          <CommentBlock :label="label" :field_data="getDeficiencyField" />
+          <!--<CommentBlock :name="name" :label="label" :field_data="getDeficiencyField" />-->
 
           <div class="grid-container">
-              <div class="col-sm-6 form-group" v-if="headers">
+              <div class="col-sm-3 form-group" v-if="headers">
                   <div class="grid-item row">
                       
                       <div class="col-sm-1 grid-column" v-for="header in headers" >
@@ -42,7 +42,7 @@
                                   />
                           </div>
                           <div class="col-sm-1">
-                            <button class="btn btn-danger btn-md" @click.prevent="addRow()" ><i class="bi bi-trash"></i></button>
+                            <button class="btn btn-danger btn-md" @click.prevent="removeRow(row_no)" ><i class="bi bi-trash"></i></button>
                           </div>
                 </div>
               </div>
@@ -75,13 +75,14 @@ const GridBlock = {
     }
   },
   computed: {
-    getDeficiencyField: function(){
+    //TODO determine if this is needed
+    /*getDeficiencyField: function(){
       var def = this.field_data[0][this.name + '-deficiency-field']
       if (def==null){
         return {'deficiency-value': null}
       }
       return this.field_data[0][this.name + '-deficiency-field']
-    },
+    },*/
     showAddRow: function(){
       return this.show_add_row
     },
@@ -108,12 +109,17 @@ const GridBlock = {
       };
       self.field_data.push(fieldObj);
     },
-    removeRow: function(e) {
-
-    },
-    addColumn: function(e) {
-    },
-    addArea: function(e) {
+    removeRow: function(row_num) {
+      const self = this;
+      if (self.field_data.length > 1) {
+        self.field_data.splice(row_num,1);
+      } else {
+        let fieldObj = Object.assign({}, this.field_data[0]);
+        for(let key in fieldObj) {
+          fieldObj[key] = {'value':'', 'error':''};
+        };
+        self.field_data[0] = fieldObj;
+      }
     },
     setDateValue: function(value, row, name, readonly) {
       const self = this;

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/access.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/access.vue
@@ -311,10 +311,11 @@ export default {
             await this.save_wo();
             this.form=document.forms.internal_returns_form;
 
-            let request = fetch_util.fetchUrl(helpers.add_endpoint_json(api_endpoints.returns,this.returns.id+'/accept'),{
-                            emulateJSON:true,
-
-            })
+            let request = fetch_util.fetchUrl(
+                helpers.add_endpoint_json(api_endpoints.returns,this.returns.id+'/accept'),
+                {method:'POST'},
+                {emulateJSON:true}
+            )
             request.then((response)=>{
 
                 // Return to dashboard.

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/access.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/access.vue
@@ -62,8 +62,8 @@
                     <!-- Workflow Actions -->
                     <div v-show="showActionButtons" class="col-sm-12 top-buffer-s">
                         <strong>Action</strong><br/><br/>
-                        <button style="width:255px;" class="btn btn-primary btn-md" @click.prevent="acceptReturn()">Accept</button><br/><br/>
-                        <button style="width:255px;" class="btn btn-primary btn-md" @click.prevent="amendmentRequest()">Request Amendment</button>
+                        <button class="btn btn-primary btn-md" @click.prevent="acceptReturn()">Accept</button><br/><br/>
+                        <button class="btn btn-primary btn-md" @click.prevent="amendmentRequest()">Request Amendment</button>
                         <br/><br/>
                     </div>
 

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/return.vue
@@ -150,7 +150,6 @@ export default {
         const { showNotification } = props;
         this.form=document.forms.internal_returns_form;
         var data = new FormData(this.form);
-
         let request = fetch_util.fetchUrl(helpers.add_endpoint_json(api_endpoints.returns,this.returns.id+'/officer_comments'),{method:'POST', body:JSON.stringify(data)},{
                       emulateJSON:true,
 

--- a/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/return.vue
+++ b/wildlifecompliance/frontend/wildlifecompliance/src/components/internal/returns/return.vue
@@ -199,45 +199,43 @@ export default {
         });
         data.append('transfer', speciesJSON)
       }
-        let request = fetch_util.fetchUrl(helpers.add_endpoint_json(api_endpoints.returns,this.returns.id+'/save'),{method:'POST', body:data},{
-            emulateJSON:true,
-        })
-        request.then((response)=>{
-            let species_id = this.returns.sheet_species;
-            this.setReturns(response);
-            this.returns.sheet_species = species_id;
-            this.returns.species = species_id;
-            this.is_saving = false
-            this.disable_submit = false;
-            this.disable_exit = false;
-            this.disable_continue = false;
-            this.spinner_exit = false;
-            this.spinner_continue = false;
-        if (andContinue) { 
-
+      let request = fetch_util.fetchUrl(helpers.add_endpoint_json(api_endpoints.returns,this.returns.id+'/save'),{method:'POST', body:data},{
+          emulateJSON:true,
+      })
+      request.then((response)=>{
+          let species_id = this.returns.sheet_species;
+          this.setReturns(response);
+          if (species_id != null) {
+              this.returns.sheet_species = species_id;
+              this.returns.species = species_id;
+          }
+          this.is_saving = false
+          this.disable_submit = false;
+          this.disable_exit = false;
+          this.disable_continue = false;
+          this.spinner_exit = false;
+          this.spinner_continue = false;
+          if (andContinue) { 
             swal.fire( 'Save', 
                     'Return Details Saved', 
                     'success'
             )
-
-            } else { // route back to main dashboard
-
+          } else { // route back to main dashboard
             this.$router.push({name:"internal-returns-dash",});
-
-            }
-        },(error)=>{
-            this.is_saving = false
-            this.disable_submit = false;
-            this.disable_exit = false;
-            this.disable_continue = false;
-            this.spinner_exit = false;
-            this.spinner_continue = false;
-            console.log(error);
-            swal.fire('Error',
-                'There was an error saving your return details.<br/>' + error.body,
-                'error'
-            )
-        });
+          }
+      },(error)=>{
+          this.is_saving = false
+          this.disable_submit = false;
+          this.disable_exit = false;
+          this.disable_continue = false;
+          this.spinner_exit = false;
+          this.spinner_continue = false;
+          console.log(error);
+          swal.fire('Error',
+              'There was an error saving your return details.<br/>' + error.body,
+              'error'
+          )
+      });
     },
   },
   beforeRouteEnter: function(to, from, next){


### PR DESCRIPTION
- Fixed Return Data grid edit and spreadsheet upload
- Fixed Returns Accept button
- Allow Internal users to edit returns in draft, due, and overdue status
- Restrict editing once Return is with curator, accepted, etc
- Other minor returns related fixes
- Replaced bulk_creates for return data so sanitise mixin can work

NOTE: Some additional work may be required to further improve current returns workflow, also spreadsheet template will need to be adjusted to work with existing schema